### PR TITLE
Edits to Chat wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@
  
 # What it's useful for
 
-Enabling this skill automatically turns on notifications and provides commands
+Enabling this skill turns on notifications and provides commands
 for GitHub activities from Slack or Microsoft Teams. 
 
-This skill uses the Atomist Chat integration, which needs to be configured
+This skill uses either the Slack or Microsoft Teams integration, which needs to be configured
 before using the skill. To choose channels to receive notifications from
 repositories, link them on the **Manage > Integrations > Slack** or 
 **Manage > Integrations > Microsoft Teams** page.
@@ -20,11 +20,11 @@ linking, see [the documentation](https://docs.atomist.com/user/slack/).
 Connect and configure these integrations:
 
 1. **GitHub**
-2. **Chat**
+2. **Slack** or **Microsoft Teams**
 
 The **GitHub** integration must be configured in order to use this skill.
-At least one repository must be selected. This skill requires a **Chat**
-integration to be configured and some channels to be mapped to repositories.
+At least one repository must be selected. The **Slack** or **Microsoft Teams**
+integration needs to be configured.
 
 # How to configure
 

--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@
 Enabling this skill turns on notifications and provides commands
 for GitHub activities from Slack or Microsoft Teams. 
 
-This skill uses either the Slack or Microsoft Teams integration, which needs to be configured
-before using the skill. To choose channels to receive notifications from
-repositories, link them on the **Manage > Integrations > Slack** or 
-**Manage > Integrations > Microsoft Teams** page.
+This skill uses either the Slack or Microsoft Teams integration, which needs to
+be configured before using the skill. To choose channels to receive 
+notifications from repositories, link them on the **Manage > Integrations > 
+Slack** or **Manage > Integrations > Microsoft Teams** page.
 
 For more information about the Slack integration and channel repository
 linking, see [the documentation](https://docs.atomist.com/user/slack/).


### PR DESCRIPTION
* Use "Slack or Microsoft Teams" language instead of generic Chat
* Removed mapping copy since that is part of the chat provider setup